### PR TITLE
fix: bad memory align du to missing derive c,packed

### DIFF
--- a/src/protocols/arp.rs
+++ b/src/protocols/arp.rs
@@ -1,6 +1,7 @@
 use super::super::utils;
 
 #[derive(Debug)]
+#[repr(C, packed)]
 pub struct ArpHeader {
   // hardware type
   pub h_type: u16,


### PR DESCRIPTION
### Description 

Du to missing derive `c` and `packed` the struct was missing up, making struct field not where it should be. 
Leading to non sens value for some fields.