### PR TITLE
Replace the invalid cast_slice_to_reference function by a fast safe copy version

### DIFF
--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -2,7 +2,7 @@ mod utils;
 
 pub mod protocols {
 	pub mod ethernet;
-  	pub mod arp;
+	pub mod arp;
 	pub mod ipv4;
 }
 

--- a/src/protocols/arp.rs
+++ b/src/protocols/arp.rs
@@ -1,5 +1,6 @@
-use std::mem::size_of;
 use crate::utils::bytes_of_mut;
+use std::fmt;
+use std::mem::size_of;
 
 /// ARP op code
 ///
@@ -56,7 +57,7 @@ fn op_as_str(op: u16) -> &'static str {
 /// * `h_len` for the hardware address length, corresponding of the number of bytes for the hardware address, example 6 for mac addresses
 /// * `p_len` for the protocol address length, corresponding of the number of bytes for the protocol address, example 4 for ipv4 addresses
 /// * `op_code` for the operation code, defined by the OP struct
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Default, Clone, Copy)]
 #[repr(C, packed)]
 pub struct ArpHeader {
   /// hardware type
@@ -82,6 +83,18 @@ impl ArpHeader {
     } else {
       None
     }
+  }
+}
+
+impl fmt::Debug for ArpHeader {
+  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fmt.debug_struct("ArpHeader")
+      .field("h_type", &self.h_type.to_be())
+      .field("p_type", &self.p_type.to_be())
+      .field("h_len", &self.h_len.to_be())
+      .field("p_len", &self.p_len.to_be())
+      .field("op_code", &op_as_str(self.op_code.to_be()))
+      .finish()
   }
 }
 

--- a/src/protocols/arp.rs
+++ b/src/protocols/arp.rs
@@ -1,4 +1,4 @@
-use crate::utils::bytes_of_mut;
+use crate::utils::cow_struct;
 use std::fmt;
 use std::mem::size_of;
 
@@ -74,16 +74,6 @@ pub struct ArpHeader {
 
 impl ArpHeader {
   pub const SIZE: usize = size_of::<Self>();
-
-  pub fn from_bytes(bytes: &[u8]) -> Option<ArpHeader> {
-    if bytes.len() == Self::SIZE {
-      let mut elem = ArpHeader::default();
-      bytes_of_mut(&mut elem).copy_from_slice(bytes);
-      Some(elem)
-    } else {
-      None
-    }
-  }
 }
 
 impl fmt::Debug for ArpHeader {
@@ -125,7 +115,7 @@ impl fmt::Debug for ArpHeader {
 pub fn decode(data: &[u8]) {
   if data.len() >= ArpHeader::SIZE {
     let (slice, _data) = data.split_at(ArpHeader::SIZE);
-    match ArpHeader::from_bytes(slice) {
+    match cow_struct::<ArpHeader>(slice) {
       Some(header) => {
         println!("{:#?}", header);
         let p_type = header.p_type.to_be();

--- a/src/protocols/ethernet.rs
+++ b/src/protocols/ethernet.rs
@@ -1,5 +1,5 @@
 use std::mem::size_of;
-use crate::utils::bytes_of_mut;
+use crate::utils::cow_struct;
 
 use super::arp;
 use super::ipv4;
@@ -14,16 +14,6 @@ pub struct EthernetHeader {
 
 impl EthernetHeader {
   pub const SIZE: usize = size_of::<Self>();
-
-  pub fn from_bytes(bytes: &[u8]) -> Option<EthernetHeader> {
-    if bytes.len() == Self::SIZE {
-      let mut elem = EthernetHeader::default();
-      bytes_of_mut(&mut elem).copy_from_slice(bytes);
-      Some(elem)
-    } else {
-      None
-    }
-  }
 }
 
 const ETHERNET_TYPE_PUP: u16 = 0x0200;
@@ -41,7 +31,7 @@ const ETHERNET_TYPE_LOOPBACK: u16 = 0x9000;
 pub fn decode(data: &[u8]) {
   if data.len() >= EthernetHeader::SIZE {
     let (slice, _data) = data.split_at(EthernetHeader::SIZE);
-    match EthernetHeader::from_bytes(slice) {
+    match cow_struct::<EthernetHeader>(slice) {
       Some(header) => {
         let t = header.ether_type.to_be();
         let current_data = &data[std::mem::size_of::<EthernetHeader>()..];

--- a/src/protocols/ipv4.rs
+++ b/src/protocols/ipv4.rs
@@ -4,28 +4,30 @@ use crate::utils::bytes_of_mut;
 #[derive(Default, Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct IPV4Header {
-	pub version_and_header_len: u8,
-	pub type_of_service: u8,
-	pub total_len: u16,
-	pub identification: u16,
-	pub fragment_offset: u16,
-	pub time_to_live: u8,
-	pub protocol: u8,
-	pub checksum: u16,
-	pub src: u32,
-	pub dst: u32,
+  pub version_and_header_len: u8,
+  pub type_of_service: u8,
+  pub total_len: u16,
+  pub identification: u16,
+  pub fragment_offset: u16,
+  pub time_to_live: u8,
+  pub protocol: u8,
+  pub checksum: u16,
+  pub src: u32,
+  pub dst: u32,
 }
 
 impl IPV4Header {
-	pub fn from_bytes(bytes: &[u8]) -> Option<IPV4Header> {
-	  if bytes.len() == size_of::<IPV4Header>() {
-	    let mut elem = IPV4Header::default();
-	    bytes_of_mut(&mut elem).copy_from_slice(bytes);
-	    Some(elem)
-	  } else {
-	    None
-	  }
-	}
+  pub const SIZE: usize = size_of::<Self>();
+
+  pub fn from_bytes(bytes: &[u8]) -> Option<IPV4Header> {
+    if bytes.len() == size_of::<IPV4Header>() {
+      let mut elem = IPV4Header::default();
+      bytes_of_mut(&mut elem).copy_from_slice(bytes);
+      Some(elem)
+    } else {
+      None
+    }
+  }
 }
 
 const IPPROTO_IP: u8 = 0;
@@ -55,44 +57,47 @@ const IPPROTO_MPLS: u8 = 137;
 const IPPROTO_RAW: u8 = 255;
 
 pub fn decode(data: &[u8]) {
-	match IPV4Header::from_bytes(data) {
-		Some(header) => {
-			let version = (header.version_and_header_len & 0xF0) >> 4;
-			if version != 4 {
-				println!("Invalid ip version: {:?}", version);
-			} else {
-				let len_bytes: usize = ((header.version_and_header_len & 0xF) * 32 / 8).into();
-				let _current_data = &data[len_bytes..];
-				match header.protocol {
-					IPPROTO_IP => println!("IP"),
-					IPPROTO_ICMP => println!("ICMP"),
-					IPPROTO_IGMP => println!("IGMP"),
-					IPPROTO_IPIP => println!("IPIP"),
-					IPPROTO_TCP => println!("TCP"),
-					IPPROTO_EGP => println!("EGP"),
-					IPPROTO_PUP => println!("PUP"),
-					IPPROTO_UDP => println!("UDP"),
-					IPPROTO_IDP => println!("IDP"),
-					IPPROTO_TP => println!("TP"),
-					IPPROTO_DCCP => println!("DCCP"),
-					IPPROTO_IPV6 => println!("IPV6"),
-					IPPROTO_RSVP => println!("RSVP"),
-					IPPROTO_GRE => println!("GRE"),
-					IPPROTO_ESP => println!("ESP"),
-					IPPROTO_AH => println!("AH"),
-					IPPROTO_MTP => println!("MTP"),
-					IPPROTO_BEETPH => println!("BEETPH"),
-					IPPROTO_ENCAP => println!("ENCAP"),
-					IPPROTO_PIM => println!("PIM"),
-					IPPROTO_COMP => println!("COMP"),
-					IPPROTO_SCTP => println!("SCTP"),
-					IPPROTO_UDPLITE => println!("UDPLITE"),
-					IPPROTO_MPLS => println!("MPLS"),
-					IPPROTO_RAW => println!("RAW"),
-					_ => println!("unknown protocol: {}", format!("{:#X}", header.protocol)),
-				}
-			}
-		},
-		None => println!("ip decode error: {:?}", "Truncated payload"),
-	}
+  if data.len() >= IPV4Header::SIZE {
+    let (slice, _data) = data.split_at(IPV4Header::SIZE);
+    match IPV4Header::from_bytes(slice) {
+      Some(header) => {
+        let version = (header.version_and_header_len & 0xF0) >> 4;
+        if version != 4 {
+          println!("Invalid ip version: {:?}", version);
+        } else {
+          let len_bytes: usize = ((header.version_and_header_len & 0xF) * 32 / 8).into();
+          let _current_data = &data[len_bytes..];
+          match header.protocol {
+            IPPROTO_IP => println!("IP"),
+            IPPROTO_ICMP => println!("ICMP"),
+            IPPROTO_IGMP => println!("IGMP"),
+            IPPROTO_IPIP => println!("IPIP"),
+            IPPROTO_TCP => println!("TCP"),
+            IPPROTO_EGP => println!("EGP"),
+            IPPROTO_PUP => println!("PUP"),
+            IPPROTO_UDP => println!("UDP"),
+            IPPROTO_IDP => println!("IDP"),
+            IPPROTO_TP => println!("TP"),
+            IPPROTO_DCCP => println!("DCCP"),
+            IPPROTO_IPV6 => println!("IPV6"),
+            IPPROTO_RSVP => println!("RSVP"),
+            IPPROTO_GRE => println!("GRE"),
+            IPPROTO_ESP => println!("ESP"),
+            IPPROTO_AH => println!("AH"),
+            IPPROTO_MTP => println!("MTP"),
+            IPPROTO_BEETPH => println!("BEETPH"),
+            IPPROTO_ENCAP => println!("ENCAP"),
+            IPPROTO_PIM => println!("PIM"),
+            IPPROTO_COMP => println!("COMP"),
+            IPPROTO_SCTP => println!("SCTP"),
+            IPPROTO_UDPLITE => println!("UDPLITE"),
+            IPPROTO_MPLS => println!("MPLS"),
+            IPPROTO_RAW => println!("RAW"),
+            _ => println!("unknown protocol: {}", format!("{:#X}", header.protocol)),
+          }
+        }
+      },
+      None => println!("ip decode error: {:?}", "Truncated payload"),
+    }
+  }
 }

--- a/src/protocols/ipv4.rs
+++ b/src/protocols/ipv4.rs
@@ -1,5 +1,5 @@
 use std::mem::size_of;
-use crate::utils::bytes_of_mut;
+use crate::utils::cow_struct;
 
 #[derive(Default, Debug, Clone, Copy)]
 #[repr(C, packed)]
@@ -18,16 +18,6 @@ pub struct IPV4Header {
 
 impl IPV4Header {
   pub const SIZE: usize = size_of::<Self>();
-
-  pub fn from_bytes(bytes: &[u8]) -> Option<IPV4Header> {
-    if bytes.len() == size_of::<IPV4Header>() {
-      let mut elem = IPV4Header::default();
-      bytes_of_mut(&mut elem).copy_from_slice(bytes);
-      Some(elem)
-    } else {
-      None
-    }
-  }
 }
 
 const IPPROTO_IP: u8 = 0;
@@ -59,7 +49,7 @@ const IPPROTO_RAW: u8 = 255;
 pub fn decode(data: &[u8]) {
   if data.len() >= IPV4Header::SIZE {
     let (slice, _data) = data.split_at(IPV4Header::SIZE);
-    match IPV4Header::from_bytes(slice) {
+    match cow_struct::<IPV4Header>(slice) {
       Some(header) => {
         let version = (header.version_and_header_len & 0xF0) >> 4;
         if version != 4 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,1 +1,9 @@
-pub mod cast;
+use std::{slice, mem};
+
+/// Gives a mutable slice of the bytes of the given element.
+#[inline]
+pub fn bytes_of_mut<T: 'static + Copy>(elem: &mut T) -> &mut [u8] {
+    let slice = slice::from_mut(elem);
+    let new_len = mem::size_of_val(slice);
+    unsafe { slice::from_raw_parts_mut(slice.as_ptr() as *mut u8, new_len) }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::{slice, mem};
 
 /// Gives a mutable slice of the bytes of the given element.
@@ -6,4 +7,21 @@ pub fn bytes_of_mut<T: 'static + Copy>(elem: &mut T) -> &mut [u8] {
     let slice = slice::from_mut(elem);
     let new_len = mem::size_of_val(slice);
     unsafe { slice::from_raw_parts_mut(slice.as_ptr() as *mut u8, new_len) }
+}
+
+/// Returns either a borrowed version of the struct if target bytes are well aligned
+/// and backups on an owned version that involves copying the bytes.
+///
+/// Returns None in case the number of bytes doesn't match the struct size.
+#[inline]
+pub fn cow_struct<T: 'static + Copy + Default>(bytes: &[u8]) -> Option<Cow<T>> {
+    if bytes.len() != mem::size_of::<T>() {
+        None
+    } else if (bytes.as_ptr() as usize) % mem::align_of::<T>() != 0 {
+        let mut elem = T::default();
+        bytes_of_mut(&mut elem).copy_from_slice(bytes);
+        Some(Cow::Owned(elem))
+    } else {
+        Some(Cow::Borrowed(unsafe { &*(bytes.as_ptr() as *const T) }))
+    }
 }

--- a/src/utils/cast.rs
+++ b/src/utils/cast.rs
@@ -1,7 +1,0 @@
-pub fn cast_slice_to_reference<T>(data: &[u8]) -> std::result::Result::<&T, &str> {
-	if data.len() < std::mem::size_of::<T>() {
-		Err("Truncated payload")
-	} else {
-		Ok(unsafe { &*(data.as_ptr() as *const T) })
-	}   
-}


### PR DESCRIPTION
Hey @Lsh0x and @alexandre-merle,

I have removed the invalid `slice_to_reference` function as it was not checking the right alignment of the casted bytes, it [is undefined behavior to read a type](https://doc.rust-lang.org/std/ptr/fn.read_unaligned.html) from a source [that isn't correctly aligned to the type size](https://doc.rust-lang.org/reference/behavior-considered-undefined.html).

I replaced that with a simple copy function that creates a type on the stack (valid alignment) and copies the bytes into the type itself. To do so I introduced a `bytes_of_mut` function [that I have gathered from the bytemuck crate](https://docs.rs/bytemuck/1.5.0/bytemuck/fn.bytes_of_mut.html) that I recommend you to use.

About the speed I just want you to know that copying a bunch of bytes doesn't trigger a call to the memcpy function, the types are 8, 14, and 20 bytes for the `ArpHeader`, `EthernetHeader`, and `IPV4Header` structs [respectively](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=548943e51e58f16b073104125f592d57), it is one call to the copy to register assembly operation.

There is no call to any external/internal function at any point in this godbolt example: https://godbolt.org/z/TE87KP