### PR TITLE
Refactor/consistant headers naming

### DIFF
--- a/src/protocols/ah.rs
+++ b/src/protocols/ah.rs
@@ -15,7 +15,7 @@ use super::ip;
 /// * https://tools.ietf.org/html/rfc4302
 #[derive(Default, Debug, Clone, Copy)]
 #[repr(C, packed)]
-pub struct AHHeader {
+pub struct Header {
     /// type of the next header
     pub next_header: u8,
     /// length of the authentication data following the header
@@ -30,14 +30,14 @@ pub struct AHHeader {
     pub seq_number: u32,
 }
 
-impl AHHeader {
+impl Header {
     pub const SIZE: usize = size_of::<Self>();
 }
 
 pub fn decode(data: &[u8]) {
-    if data.len() >= AHHeader::SIZE {
-        let (slice, _data) = data.split_at(AHHeader::SIZE);
-        match cow_struct::<AHHeader>(slice) {
+    if data.len() >= Header::SIZE {
+        let (slice, _data) = data.split_at(Header::SIZE);
+        match cow_struct::<Header>(slice) {
             Some(header) => {
                 println!(
                     "protocol {:?}",

--- a/src/protocols/arp.rs
+++ b/src/protocols/arp.rs
@@ -52,7 +52,7 @@ fn op_as_str(op: u16) -> &'static str {
 
 /// ARP Header structure
 ///
-/// The ArpHeader define all the field of an arp request header
+/// The Header define all the field of an arp request header
 /// * `h_type` for the harware type, like ethernet for example
 /// * `p_type` for the protocol type, like ip for example
 /// * `h_len` for the hardware address length, corresponding of the number of bytes for the hardware address, example 6 for mac addresses
@@ -60,7 +60,7 @@ fn op_as_str(op: u16) -> &'static str {
 /// * `op_code` for the operation code, defined by the OP struct
 #[derive(Default, Clone, Copy)]
 #[repr(C, packed)]
-pub struct ArpHeader {
+pub struct Header {
     /// hardware type
     pub h_type: u16,
     /// protocol type
@@ -73,13 +73,13 @@ pub struct ArpHeader {
     pub op_code: u16,
 }
 
-impl ArpHeader {
+impl Header {
     pub const SIZE: usize = size_of::<Self>();
 }
 
-impl fmt::Debug for ArpHeader {
+impl fmt::Debug for Header {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("ArpHeader")
+        fmt.debug_struct("Header")
             .field("h_type", &self.h_type.to_be())
             .field("p_type", &ethernet::ether_type_as_str(self.p_type.to_be()))
             .field("h_len", &self.h_len.to_be())
@@ -111,9 +111,9 @@ impl fmt::Debug for ArpHeader {
 /// }
 ///```
 pub fn decode(data: &[u8]) {
-    if data.len() >= ArpHeader::SIZE {
-        let (header_bytes, _data) = data.split_at(ArpHeader::SIZE);
-        match cow_struct::<ArpHeader>(header_bytes) {
+    if data.len() >= Header::SIZE {
+        let (header_bytes, _data) = data.split_at(Header::SIZE);
+        match cow_struct::<Header>(header_bytes) {
             Some(header) => println!("{:#?}", header),
             None => println!("Error::arp {:?}", "Truncated payload"),
         }

--- a/src/protocols/esp.rs
+++ b/src/protocols/esp.rs
@@ -12,7 +12,7 @@ use std::mem::size_of;
 /// * https://tools.ietf.org/html/rfc8221
 #[derive(Default, Debug, Clone, Copy)]
 #[repr(C, packed)]
-pub struct ESPHeader {
+pub struct Header {
     /// security parameters index, random value to combine with the destination ip address and
     /// security protocol
     pub spi: u32,
@@ -21,14 +21,14 @@ pub struct ESPHeader {
     pub seq_number: u32,
 }
 
-impl ESPHeader {
+impl Header {
     pub const SIZE: usize = size_of::<Self>();
 }
 
 pub fn decode(data: &[u8]) {
-    if data.len() >= ESPHeader::SIZE {
-        let (header_bytes, _next_data) = data.split_at(ESPHeader::SIZE);
-        match cow_struct::<ESPHeader>(header_bytes) {
+    if data.len() >= Header::SIZE {
+        let (header_bytes, _next_data) = data.split_at(Header::SIZE);
+        match cow_struct::<Header>(header_bytes) {
             Some(_) => {
                 println!("protocol::esp decoded");
             }

--- a/src/protocols/ethernet.rs
+++ b/src/protocols/ethernet.rs
@@ -7,13 +7,13 @@ use super::ipv6;
 
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C, packed)]
-pub struct EthernetHeader {
+pub struct Header {
     pub dhost: [u8; 6],
     pub shost: [u8; 6],
     pub ether_type: u16,
 }
 
-impl EthernetHeader {
+impl Header {
     pub const SIZE: usize = size_of::<Self>();
 }
 
@@ -69,9 +69,9 @@ pub fn ether_type_as_str(ether_type: u16) -> &'static str {
 }
 
 pub fn decode(data: &[u8]) {
-    if data.len() >= EthernetHeader::SIZE {
-        let (header_bytes, next_data) = data.split_at(EthernetHeader::SIZE);
-        match cow_struct::<EthernetHeader>(header_bytes) {
+    if data.len() >= Header::SIZE {
+        let (header_bytes, next_data) = data.split_at(Header::SIZE);
+        match cow_struct::<Header>(header_bytes) {
             Some(header) => {
                 let t = header.ether_type.to_be();
                 match t {

--- a/src/protocols/icmpv4.rs
+++ b/src/protocols/icmpv4.rs
@@ -14,7 +14,7 @@ use std::mem::size_of;
 /// * https://tools.ietf.org/html/rfc777
 #[derive(Default, Clone, Copy)]
 #[repr(C, packed)]
-pub struct ICMPV4Header {
+pub struct Header {
     /// type of the control message
     pub t: u8,
     /// code of the controle message
@@ -25,7 +25,7 @@ pub struct ICMPV4Header {
     pub rest: u32,
 }
 
-impl ICMPV4Header {
+impl Header {
     pub const SIZE: usize = size_of::<Self>();
 }
 
@@ -88,9 +88,9 @@ fn icmp_v4_code_to_str(code: u8) -> &'static str {
 /// Usually called by the proto on top of it, like the ethernetHeader struct, that will
 /// once the ethernet type have been detected to be arp, it can then decode the arp header using this.
 pub fn decode(data: &[u8]) {
-    if data.len() >= ICMPV4Header::SIZE {
-        let (header_bytes, _data) = data.split_at(ICMPV4Header::SIZE);
-        match cow_struct::<ICMPV4Header>(header_bytes) {
+    if data.len() >= Header::SIZE {
+        let (header_bytes, _data) = data.split_at(Header::SIZE);
+        match cow_struct::<Header>(header_bytes) {
             Some(header) => println!(
                 "protocol::icmpv4 type {:?}",
                 icmp_v4_code_to_str(header.t.to_be())

--- a/src/protocols/icmpv6.rs
+++ b/src/protocols/icmpv6.rs
@@ -14,7 +14,7 @@ use std::mem::size_of;
 /// * https://tools.ietf.org/html/rfc777
 #[derive(Default, Clone, Copy)]
 #[repr(C, packed)]
-pub struct ICMPV6Header {
+pub struct Header {
     /// type of the control message
     pub t: u8,
     /// code of the controle message
@@ -25,7 +25,7 @@ pub struct ICMPV6Header {
     pub rest: u32,
 }
 
-impl ICMPV6Header {
+impl Header {
     pub const SIZE: usize = size_of::<Self>();
 }
 
@@ -79,9 +79,9 @@ fn icmp_v6_code_to_str(code: u8) -> &'static str {
 /// Usually called by the proto on top of it, like the ethernetHeader struct, that will
 /// once the ethernet type have been detected to be arp, it can then decode the arp header using this.
 pub fn decode(data: &[u8]) {
-    if data.len() >= ICMPV6Header::SIZE {
-        let (header_bytes, _data) = data.split_at(ICMPV6Header::SIZE);
-        match cow_struct::<ICMPV6Header>(header_bytes) {
+    if data.len() >= Header::SIZE {
+        let (header_bytes, _data) = data.split_at(Header::SIZE);
+        match cow_struct::<Header>(header_bytes) {
             Some(header) => println!(
                 "protocol::icmpv6 type {:?}",
                 icmp_v6_code_to_str(header.t.to_be())

--- a/src/protocols/ipv4.rs
+++ b/src/protocols/ipv4.rs
@@ -7,7 +7,7 @@ use super::ip;
 
 #[derive(Default, Debug, Clone, Copy)]
 #[repr(C, packed)]
-pub struct IPV4Header {
+pub struct Header {
     /// version of the ip protocol and the lenght of the header since it can be variable du to options
     pub version_and_header_len: u8,
     pub type_of_service: u8,
@@ -21,14 +21,14 @@ pub struct IPV4Header {
     pub dst: u32,
 }
 
-impl IPV4Header {
+impl Header {
     pub const SIZE: usize = size_of::<Self>();
 }
 
 pub fn decode(data: &[u8]) {
-    if data.len() >= IPV4Header::SIZE {
-        let (header_bytes, _next_data) = data.split_at(IPV4Header::SIZE);
-        match cow_struct::<IPV4Header>(header_bytes) {
+    if data.len() >= Header::SIZE {
+        let (header_bytes, _next_data) = data.split_at(Header::SIZE);
+        match cow_struct::<Header>(header_bytes) {
             Some(header) => {
                 let version = (header.version_and_header_len & 0xF0) >> 4;
                 if version != 4 {

--- a/src/protocols/ipv6.rs
+++ b/src/protocols/ipv6.rs
@@ -27,7 +27,7 @@ use super::ip;
 
 #[derive(Default, Debug, Clone, Copy)]
 #[repr(C, packed)]
-pub struct IPV6Header {
+pub struct Header {
     /// contains version traffic class and flow label
     pub version_traffic_class_flow_label: u32,
     /// length of the payload
@@ -42,7 +42,7 @@ pub struct IPV6Header {
     pub dst: [u32; 4],
 }
 
-impl IPV6Header {
+impl Header {
     pub const SIZE: usize = size_of::<Self>();
 }
 
@@ -68,9 +68,9 @@ impl IPV6Header {
 /// }
 ///```
 pub fn decode(data: &[u8]) {
-    if data.len() >= IPV6Header::SIZE {
-        let (slice, next_data) = data.split_at(IPV6Header::SIZE);
-        match cow_struct::<IPV6Header>(slice) {
+    if data.len() >= Header::SIZE {
+        let (slice, next_data) = data.split_at(Header::SIZE);
+        match cow_struct::<Header>(slice) {
             Some(header) => {
                 let version = (header.version_traffic_class_flow_label & 0xF0) >> 4;
                 if version != 6 {


### PR DESCRIPTION
### Description 

Use a consistent naming for header. allowing for all protocols to do: 
```
<Protocol>::Header
```